### PR TITLE
Use the 'Z' timezone indicator for ISO datetime strings

### DIFF
--- a/src/nsidc/metgen/netcdf_reader.py
+++ b/src/nsidc/metgen/netcdf_reader.py
@@ -106,4 +106,6 @@ def ensure_iso(datetime_str):
     Parse ISO-standard datetime strings without a timezone identifier.
     """
     iso_obj = parse(datetime_str)
-    return iso_obj.replace(tzinfo=timezone.utc).isoformat(timespec='milliseconds')
+    return iso_obj.replace(tzinfo=timezone.utc) \
+        .isoformat(timespec='milliseconds') \
+        .replace("+00:00", "Z")

--- a/tests/test_netcdf_reader.py
+++ b/tests/test_netcdf_reader.py
@@ -47,14 +47,14 @@ def test_no_other_duplicate_values(big_xdata, big_ydata):
     assert len(result_set) == len(result) - 1
 
 @pytest.mark.parametrize("input,expected", [
-    pytest.param('2001-01-01', '2001-01-01T00:00:00.000+00:00', id="Date and no time"),
-    pytest.param('2001-01-01 18:59:59', '2001-01-01T18:59:59.000+00:00', id="Date with time"),
-    pytest.param('2001-01-01 18:59.5', '2001-01-01T18:59:30.000+00:00', id="Datetime and fractional minutes"),
-    pytest.param('2001-01-01 18:59.500', '2001-01-01T18:59:30.000+00:00', id="Datetime and zero padded fractional minutes"),
-    pytest.param('2001-01-01 18:59.34', '2001-01-01T18:59:20.000+00:00', id="Datetime and other fractional minutes value"),
-    pytest.param('2001-01-01 18:59.999', '2001-01-01T18:59:59.000+00:00', id="Datetime and other fractional minutes value"),
-    pytest.param('2001-01-01 18:59:20.666', '2001-01-01T18:59:20.666+00:00', id="Datetime and fractional seconds"),
-    pytest.param('2001-01-01 18:59', '2001-01-01T18:59:00.000+00:00', id="Datetime and hours/minutes"),
+    pytest.param('2001-01-01', '2001-01-01T00:00:00.000Z', id="Date and no time"),
+    pytest.param('2001-01-01 18:59:59', '2001-01-01T18:59:59.000Z', id="Date with time"),
+    pytest.param('2001-01-01 18:59.5', '2001-01-01T18:59:30.000Z', id="Datetime and fractional minutes"),
+    pytest.param('2001-01-01 18:59.500', '2001-01-01T18:59:30.000Z', id="Datetime and zero padded fractional minutes"),
+    pytest.param('2001-01-01 18:59.34', '2001-01-01T18:59:20.000Z', id="Datetime and other fractional minutes value"),
+    pytest.param('2001-01-01 18:59.999', '2001-01-01T18:59:59.000Z', id="Datetime and other fractional minutes value"),
+    pytest.param('2001-01-01 18:59:20.666', '2001-01-01T18:59:20.666Z', id="Datetime and fractional seconds"),
+    pytest.param('2001-01-01 18:59', '2001-01-01T18:59:00.000Z', id="Datetime and hours/minutes"),
 ])
 def test_correctly_reads_date_time_strings(input, expected):
     result = netcdf_reader.ensure_iso(input)


### PR DESCRIPTION
Pending further Cumulus tests to determine if Z is required or if we can use the (more?) standard offset format (+00:00).