### PR TITLE
Change the default Kinesis stream name

### DIFF
--- a/src/nsidc/metgen/constants.py
+++ b/src/nsidc/metgen/constants.py
@@ -1,6 +1,6 @@
 # Default configuration values
 DEFAULT_CUMULUS_ENVIRONMENT = 'uat'
-DEFAULT_STAGING_KINESIS_STREAM = 'nsidc-cumulus-${environment}-ciss_notification'
+DEFAULT_STAGING_KINESIS_STREAM = 'nsidc-cumulus-${environment}-external_notification'
 DEFAULT_STAGING_BUCKET_NAME = 'nsidc-cumulus-${environment}-ingest-staging'
 DEFAULT_WRITE_CNM_FILE = False
 DEFAULT_CHECKSUM_TYPE = 'SHA256'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,7 +120,7 @@ def test_get_configuration_value_interpolates_the_environment(cfg_parser):
     assert result == "xyzzy-uat-stream"
 
 @pytest.mark.parametrize("section,option,expected", [
-        ("Destination", "kinesis_stream_name", f"nsidc-cumulus-{constants.DEFAULT_CUMULUS_ENVIRONMENT}-ciss_notification"),
+        ("Destination", "kinesis_stream_name", f"nsidc-cumulus-{constants.DEFAULT_CUMULUS_ENVIRONMENT}-external_notification"),
         ("Destination", "staging_bucket_name", f"nsidc-cumulus-{constants.DEFAULT_CUMULUS_ENVIRONMENT}-ingest-staging"),
         ("Destination", "write_cnm_file", constants.DEFAULT_WRITE_CNM_FILE),
         ("Settings", "checksum_type", constants.DEFAULT_CHECKSUM_TYPE),


### PR DESCRIPTION
Troy said that we should be using the *-external_notification stream.