### PR TITLE
issue-66

### DIFF
--- a/src/nsidc/metgen/cli.py
+++ b/src/nsidc/metgen/cli.py
@@ -33,11 +33,13 @@ def info(config_filename):
 @click.option('-e', '--env', help='environment', default=constants.DEFAULT_CUMULUS_ENVIRONMENT, show_default=True)
 @click.option('-n', '--number', help="Process at most 'count' granules.", metavar='count', required=False, default=-1)
 @click.option('-wc', '--write-cnm', is_flag=True, required=False, default=None, help="Write CNM messages to files.")
-def process(config_filename, env, write_cnm, number):
+@click.option('-o', '--overwrite', is_flag=True, required=False, default=None, help="Overwrite existing UMM-G files.")
+def process(config_filename, env, overwrite, write_cnm, number):
     """Processes science data files based on configuration file contents."""
     click.echo(metgen.banner())
     overrides = {
         'write_cnm_file': write_cnm,
+        'overwrite_ummg': overwrite,
         'number': number
     }
     configuration = config.configuration(config.config_parser_factory(config_filename), overrides, env)

--- a/src/nsidc/metgen/config.py
+++ b/src/nsidc/metgen/config.py
@@ -20,6 +20,7 @@ class Config:
     kinesis_stream_name: str
     staging_bucket_name: str
     write_cnm_file: bool
+    overwrite_ummg: bool
     checksum_type: str
     number: int
 
@@ -90,6 +91,7 @@ def configuration(config_parser, overrides, environment=constants.DEFAULT_CUMULU
         'kinesis_stream_name': constants.DEFAULT_STAGING_KINESIS_STREAM,
         'staging_bucket_name': constants.DEFAULT_STAGING_BUCKET_NAME,
         'write_cnm_file': constants.DEFAULT_WRITE_CNM_FILE,
+        'overwrite_ummg': constants.DEFAULT_OVERWRITE_UMMG,
         'checksum_type': constants.DEFAULT_CHECKSUM_TYPE,
         'number': constants.DEFAULT_NUMBER,
     }
@@ -105,6 +107,7 @@ def configuration(config_parser, overrides, environment=constants.DEFAULT_CUMULU
             _get_configuration_value(environment, 'Destination', 'kinesis_stream_name', str, config_parser, overrides),
             _get_configuration_value(environment, 'Destination', 'staging_bucket_name', str, config_parser, overrides),
             _get_configuration_value(environment, 'Destination', 'write_cnm_file', bool, config_parser, overrides),
+            _get_configuration_value(environment, 'Destination', 'overwrite_ummg', bool, config_parser, overrides),
             _get_configuration_value(environment, 'Settings', 'checksum_type', str, config_parser, overrides),
             _get_configuration_value(environment, 'Settings', 'number', int, config_parser, overrides),
         )
@@ -118,7 +121,7 @@ def validate(configuration):
     validations = [
         ['data_dir', lambda dir: os.path.exists(dir), 'The data_dir does not exist.'],
         ['local_output_dir', lambda dir: os.path.exists(dir), 'The local_output_dir does not exist.'],
-        # ['ummg_dir', lambda dir: os.path.exists(dir), 'The ummg_dir does not exist.'],                 ## Not sure what validation to do
+        # ['ummg_dir', lambda dir: os.path.exists(dir), 'The ummg_dir does not exist.'],  ## validate "local_output_dir/ummg_dir" as part of issue-71
         ['kinesis_stream_name', lambda name: aws.kinesis_stream_exists(name), 'The kinesis stream does not exist.'],
         ['staging_bucket_name', lambda name: aws.staging_bucket_exists(name), 'The staging bucket does not exist.'],
     ]

--- a/src/nsidc/metgen/constants.py
+++ b/src/nsidc/metgen/constants.py
@@ -3,6 +3,7 @@ DEFAULT_CUMULUS_ENVIRONMENT = 'uat'
 DEFAULT_STAGING_KINESIS_STREAM = 'nsidc-cumulus-${environment}-external_notification'
 DEFAULT_STAGING_BUCKET_NAME = 'nsidc-cumulus-${environment}-ingest-staging'
 DEFAULT_WRITE_CNM_FILE = False
+DEFAULT_OVERWRITE_UMMG = False
 DEFAULT_CHECKSUM_TYPE = 'SHA256'
 DEFAULT_NUMBER = -1
 

--- a/src/nsidc/metgen/metgen.py
+++ b/src/nsidc/metgen/metgen.py
@@ -107,7 +107,7 @@ def scrub_json_files(path):
             if os.path.isfile(file_path) or os.path.islink(file_path):
                 os.unlink(file_path)
         except Exception as e:
-            print('Failed to delete %s. Reason: %s' % (file_path, e))
+            print('Failed to delete %s: %s' % (file_path, e))
 
 
 def process(configuration):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,5 +89,27 @@ def test_process_with_write_cnm(process_mock, configuration_mock, cli_runner):
     assert overrides['write_cnm_file'] == True
     assert result.exit_code == 0
 
+@patch('nsidc.metgen.config.configuration')
+@patch('nsidc.metgen.metgen.process')
+def test_process_with_no_overwrite(process_mock, configuration_mock, cli_runner):
+    result = cli_runner.invoke(cli, ['process', '--config', './example/modscg.ini'])
+
+    assert configuration_mock.called
+    args = configuration_mock.call_args.args
+    overrides = args[1]
+    assert overrides['overwrite_ummg'] == None
+    assert result.exit_code == 0
+
+@patch('nsidc.metgen.config.configuration')
+@patch('nsidc.metgen.metgen.process')
+def test_process_with_overwrite(process_mock, configuration_mock, cli_runner):
+    result = cli_runner.invoke(cli, ['process', '-o', '--config', './example/modscg.ini'])
+
+    assert configuration_mock.called
+    args = configuration_mock.call_args.args
+    overrides = args[1]
+    assert overrides['overwrite_ummg'] == True
+    assert result.exit_code == 0
+
 # TODO: When process raises an exception, cli handles it and displays a message
 #       and has non-zero exit code

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,6 @@ import pytest
 
 from nsidc.metgen import config
 from nsidc.metgen import constants
-from nsidc.metgen import metgen
 
 
 # Unit tests for the 'config' module functions.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ def expected_keys():
                 'kinesis_stream_name',
                 'staging_bucket_name',
                 'write_cnm_file',
+                'overwrite_ummg',
                 'checksum_type',
                 'number'])
 
@@ -95,13 +96,25 @@ def test_config_with_write_cnm(cfg_parser, expected_keys):
     assert cfg.environment == 'uat'
     assert cfg.write_cnm_file == True
 
-def test_enhanced_config():
-    myconfig = config.Config('env', 'data_dir', 'auth_id', 'version',
-                  'provider', 'output_dir', 'ummg_dir', 'stream_name', 'bucket_name',
-                  'write_cnm_file', 'checksum_type', 'number')
+def test_config_with_no_overwrite_ummg(cfg_parser, expected_keys):
+    cfg = config.configuration(cfg_parser, {}, constants.DEFAULT_CUMULUS_ENVIRONMENT)
+
+    config_keys = set(cfg.__dict__)
+    assert len(config_keys - expected_keys) == 0
+    assert not cfg.overwrite_ummg
+
+def test_config_with_overwrite_ummg(cfg_parser, expected_keys):
+    cfg_parser.set("Destination", "overwrite_ummg", 'True')
+    cfg = config.configuration(cfg_parser, {})
+
+    config_keys = set(cfg.__dict__)
+    assert len(config_keys - expected_keys) == 0
+    assert cfg.overwrite_ummg == True
+
+def test_enhanced_config(expected_keys):
+    myconfig = config.Config(*expected_keys)
     enhanced_config = myconfig.enhance('pgid')
-    assert set(['auth_id', 'version', 'producer_granule_id',
-                'submission_time', 'uuid']) <= set(enhanced_config.keys())
+    assert set(myconfig.__dict__.keys()) <= set(enhanced_config.keys())
 
 def test_get_configuration_value(cfg_parser):
     environment = constants.DEFAULT_CUMULUS_ENVIRONMENT

--- a/tests/test_metgen.py
+++ b/tests/test_metgen.py
@@ -42,6 +42,12 @@ def one_granule_metadata():
         }
     }
 
+@pytest.fixture
+def fake_config():
+    return config.Config('uat', 'data', 'auth_id', 'version',
+                         'foobar', 'output', 'ummg', 'stream',
+                         'bucket', True, True, 'sha', 3)
+
 def test_banner():
     assert len(metgen.banner()) > 0
 
@@ -91,3 +97,21 @@ def test_s3_url_simple_case():
     }
     expected = 's3://xyzzy-bucket/external/ABCD/2/abcd-1234/xyzzy.bin'
     assert metgen.s3_url(mapping, 'xyzzy.bin') == expected
+
+@patch('nsidc.metgen.metgen.scrub_json_files')
+def test_does_scrub_ummg(scrub_mock, fake_config):
+    fake_config.overwrite_ummg = True
+    metgen.prepare_output_dirs(fake_config)
+    assert scrub_mock.called
+
+@patch('nsidc.metgen.metgen.scrub_json_files')
+def test_keeps_existing_ummg(scrub_mock, fake_config):
+    fake_config.overwrite_ummg = False
+    metgen.prepare_output_dirs(fake_config)
+    assert not scrub_mock.called
+
+@patch('nsidc.metgen.metgen.scrub_json_files')
+def test_builds_output_paths(scrub_mock, fake_config):
+    ummg_path, cnm_path = metgen.prepare_output_dirs(fake_config)
+    assert str(ummg_path) == '/'.join([fake_config.local_output_dir, fake_config.ummg_dir])
+    assert str(cnm_path) == '/'.join([fake_config.local_output_dir, 'cnm'])


### PR DESCRIPTION
- Add command line and config file option to overwrite local UMM-G output files. Note: CNM files are overwritten by default.
- Populate a few more defaults when creating `ini` file