### PR TITLE
Issue-199

### DIFF
--- a/src/nsidc/metgen/metgen.py
+++ b/src/nsidc/metgen/metgen.py
@@ -820,7 +820,9 @@ def create_ummg(configuration: config.Config, granule: Granule) -> Granule:
     for data_file in granule.data_filenames:
         metadata_details[data_file] = {
             "size_in_bytes": os.path.getsize(data_file),
-            "production_date_time": configuration.date_modified,
+            "production_date_time": utilities.ensure_iso_datetime(
+                configuration.date_modified
+            ),
         } | granule.data_reader(
             data_file,
             premet_content,

--- a/src/nsidc/metgen/readers/generic.py
+++ b/src/nsidc/metgen/readers/generic.py
@@ -3,8 +3,6 @@ Generic reader for handling data file types not supported by specific readers.
 Extracts metadata from spatial/spo files when available.
 """
 
-import os.path
-
 from nsidc.metgen.readers import utilities
 
 
@@ -22,20 +20,13 @@ def extract_metadata(
     It relies on spatial/spo files for geometry information and premet files
     for temporal information.
     """
-    metadata = {
-        "size_in_bytes": os.path.getsize(data_file),
-        "production_date_time": configuration.date_modified,
-    }
+    metadata = {}
 
     # Get temporal information from premet if available
     if premet_content:
-        temporal = utilities.temporal_from_premet(premet_content)
-        if temporal:
-            metadata["temporal"] = temporal
-        else:
-            metadata["temporal"] = [configuration.date_modified]
+        metadata["temporal"] = utilities.temporal_from_premet(premet_content)
     else:
-        metadata["temporal"] = [configuration.date_modified]
+        metadata["temporal"] = []
 
     if spatial_content:
         metadata["geometry"] = spatial_content

--- a/src/nsidc/metgen/readers/netcdf_reader.py
+++ b/src/nsidc/metgen/readers/netcdf_reader.py
@@ -48,7 +48,7 @@ def extract_metadata(
         raise Exception(f"Could not open netCDF file {netcdf_path}")
 
     # Use temporal coverage from premet file if it exists
-    if premet_content is not None:
+    if premet_content:
         temporal = utilities.temporal_from_premet(premet_content)
     else:
         temporal = time_range(os.path.basename(netcdf_path), netcdf, configuration)

--- a/tests/test_generic_reader.py
+++ b/tests/test_generic_reader.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from nsidc.metgen import metgen
@@ -26,13 +26,10 @@ def test_generic_reader_extract_metadata():
     ]
 
     # Create a temporary file for testing
-    with patch("os.path.getsize", return_value=1024):
-        metadata = generic.extract_metadata(
-            "test_file.dat", premet_content, spatial_content, mock_config, "CARTESIAN"
-        )
+    metadata = generic.extract_metadata(
+        "test_file.dat", premet_content, spatial_content, mock_config, "CARTESIAN"
+    )
 
-    assert metadata["size_in_bytes"] == 1024
-    assert metadata["production_date_time"] == "2023-12-25T00:00:00.000Z"
     assert len(metadata["temporal"]) == 2
     assert metadata["geometry"] == spatial_content
 
@@ -48,19 +45,15 @@ def test_generic_reader_no_premet():
         {"Longitude": 180.0, "Latitude": -90.0},
     ]
 
-    with patch("os.path.getsize", return_value=2048):
-        metadata = generic.extract_metadata(
-            "test_file.dat",
-            None,  # No premet
-            spatial_content,
-            mock_config,
-            "GEODETIC",
-        )
+    metadata = generic.extract_metadata(
+        "test_file.dat",
+        None,  # No premet
+        spatial_content,
+        mock_config,
+        "GEODETIC",
+    )
 
-    assert metadata["size_in_bytes"] == 2048
-    assert metadata["temporal"] == [
-        "2023-12-25T00:00:00.000Z"
-    ]  # Falls back to production date
+    assert metadata["temporal"] == []
     assert metadata["geometry"] == spatial_content
 
 
@@ -77,16 +70,14 @@ def test_generic_reader_no_spatial():
         "RangeEndingTime": "13:00:00",
     }
 
-    with patch("os.path.getsize", return_value=2048):
-        metadata = generic.extract_metadata(
-            "test_file.dat",
-            premet_content,
-            [],  # No spatial
-            mock_config,
-            "GEODETIC",
-        )
+    metadata = generic.extract_metadata(
+        "test_file.dat",
+        premet_content,
+        [],  # No spatial
+        mock_config,
+        "GEODETIC",
+    )
 
-    assert metadata["size_in_bytes"] == 2048
     assert len(metadata["temporal"]) == 2  # From premet
     assert metadata["geometry"] == []  # Empty geometry
 
@@ -96,19 +87,15 @@ def test_generic_reader_no_premet_no_spatial():
     mock_config = Mock()
     mock_config.date_modified = "2023-12-25T00:00:00.000Z"
 
-    with patch("os.path.getsize", return_value=4096):
-        metadata = generic.extract_metadata(
-            "test_file.dat",
-            None,  # No premet
-            [],  # No spatial
-            mock_config,
-            "GEODETIC",
-        )
+    metadata = generic.extract_metadata(
+        "test_file.dat",
+        None,  # No premet
+        [],  # No spatial
+        mock_config,
+        "GEODETIC",
+    )
 
-    assert metadata["size_in_bytes"] == 4096
-    assert metadata["temporal"] == [
-        "2023-12-25T00:00:00.000Z"
-    ]  # Falls back to production date
+    assert metadata["temporal"] == []  # Empty temporal
     assert metadata["geometry"] == []  # Empty geometry
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -123,11 +123,17 @@ def test_correctly_reads_date_time_strings(input, expected):
             ["2020-01-01T00:00:00.000Z"],
         ),
         (
+            {
+                "RangeBeginningDate": "20200101",
+            },
+            ["2020-01-01T00:00:00.000Z"],
+        ),
+        (
             {"Begin_date": "2000-01-01", "End_date": "2000-12-31"},
             ["2000-01-01T00:00:00.000Z", "2000-12-31T00:00:00.000Z"],
         ),
         (
-            {"Begin_date": "2000-01-01", "Begin_time": "01:00:30"},
+            {"Begin_date": "20000101", "Begin_time": "01:00:30"},
             ["2000-01-01T01:00:30.000Z"],
         ),
         (


### PR DESCRIPTION
* Handle file size and default `production_date_time` value in `create_ummg` rather than having data readers deal with them.
* Ensure configuration value for `date_modified` is an ISO time-formatted string when it lands in the UMM-G file as `production_date_time`.