### PR TITLE
Issue-247-patchpatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## UNRELEASED
+
+* Issue-247 patch of the patch: Ensure polygons generated from
+ `geospatial_bounds` are counterclockwise.
+
 ## v1.12.0rc2 (2025-09-11)
 
-* Patch Issue-247: Allow for the fact that EPSG:4326 coordinates are listed in
+* Issue-247 patch: Allow for the fact that EPSG:4326 coordinates are listed in
   (lat, lon) order in the `geospatial_bounds` WKT value.
 
 ## v1.12.0rc1 (2025-09-08)


### PR DESCRIPTION
Clean up counter-clockwise checks: WKT values in EPSG:4326 need to have (lat, lon) switched to (lon, lat) before checking polygon direction.