### PR TITLE
Issue-292

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Issue 292: Exclude `.spo` files from polygon-generation logic.
+
 ## v1.12.0 (2025-09-15)
 
 * Minor version release encompassing all features in v1.12.0rc0 - v1.12.0rc3.

--- a/src/nsidc/metgen/readers/utilities.py
+++ b/src/nsidc/metgen/readers/utilities.py
@@ -221,12 +221,10 @@ def points_from_spatial(
     # TODO: We really only need to do the "spo vs spatial" check once, since the same
     # file type will (should) be used for all granules.
     if re.search(constants.SPO_SUFFIX, spatial_path):
-        parsed_points = parse_spo(gsr, points)
+        return parse_spo(gsr, points)
 
     else:
-        parsed_points = parse_spatial(points, configuration)
-
-    points = parsed_points
+        points = parse_spatial(points, configuration)
 
     # confirm the number of points makes sense for this granule spatial representation
     if not valid_spatial_config(gsr, len(points)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Shared test fixtures for the test suite."""
 
+from configparser import ConfigParser, ExtendedInterpolation
+
 import pytest
 
 from nsidc.metgen.models import CollectionMetadata
@@ -15,3 +17,23 @@ def simple_collection_metadata():
     return CollectionMetadata(
         short_name="ABCD", version="2", entry_title="Test Collection ABCD V002"
     )
+
+
+@pytest.fixture
+def cfg_parser():
+    cp = ConfigParser(interpolation=ExtendedInterpolation())
+    cp["Source"] = {"data_dir": "/data/example"}
+    cp["Collection"] = {"auth_id": "DATA-0001", "version": 42, "provider": "FOO"}
+    cp["Destination"] = {
+        "local_output_dir": "/output/here",
+        "ummg_dir": "ummg",
+        "kinesis_stream_name": "xyzzy-${environment}-stream",
+        "staging_bucket_name": "xyzzy-${environment}-bucket",
+        "write_cnm_file": False,
+    }
+    cp["Settings"] = {
+        "checksum_type": "SHA256",
+        "number": 1,
+        "log_dir": "/tmp",
+    }
+    return cp

--- a/tests/integration/configs/OLVIS1A_DUCk.ini
+++ b/tests/integration/configs/OLVIS1A_DUCk.ini
@@ -7,7 +7,7 @@ spatial_dir = ./data/spatial
 auth_id = OLVIS1A_DUCk
 version = 1
 provider = NSIDC_CUAT
-granule_regex = (?P<granuleid>.*_DUCK)\.JPG
+granule_regex = (?P<granuleid>.*_DUCk)\.JPG
 browse_regex = _reduced.JPG
 
 [Destination]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import dataclasses
 import re
-from configparser import ConfigParser, ExtendedInterpolation
+from configparser import ConfigParser
 from unittest.mock import patch
 
 import pytest
@@ -53,26 +53,6 @@ def expected_keys():
             "name",
         ]
     )
-
-
-@pytest.fixture
-def cfg_parser():
-    cp = ConfigParser(interpolation=ExtendedInterpolation())
-    cp["Source"] = {"data_dir": "/data/example"}
-    cp["Collection"] = {"auth_id": "DATA-0001", "version": 42, "provider": "FOO"}
-    cp["Destination"] = {
-        "local_output_dir": "/output/here",
-        "ummg_dir": "ummg",
-        "kinesis_stream_name": "xyzzy-${environment}-stream",
-        "staging_bucket_name": "xyzzy-${environment}-bucket",
-        "write_cnm_file": False,
-    }
-    cp["Settings"] = {
-        "checksum_type": "SHA256",
-        "number": 1,
-        "log_dir": "/tmp",
-    }
-    return cp
 
 
 def test_config_parser_without_filename():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -3,7 +3,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from nsidc.metgen import constants, metgen
+from nsidc.metgen import config, constants, metgen
 from nsidc.metgen.readers import utilities
 
 # Unit tests for the 'utilities' module functions.
@@ -294,12 +294,14 @@ def test_spo_is_geodetic():
 
 @patch("nsidc.metgen.readers.utilities.points_from_collection")
 def test_uses_spatial_from_collection(
-    collection_handler_mock, collection_spatial, simple_collection_metadata
+    collection_handler_mock, collection_spatial, simple_collection_metadata, cfg_parser
 ):
     simple_collection_metadata.spatial_extent = collection_spatial
     fake_granule = metgen.Granule("fake_granule", collection=simple_collection_metadata)
+    cfg_parser["Source"] = {"collection_geometry_override": True}
+    cfg = config.configuration(cfg_parser, {}, constants.DEFAULT_CUMULUS_ENVIRONMENT)
 
-    utilities.external_spatial_values(True, constants.CARTESIAN, fake_granule)
+    utilities.external_spatial_values(cfg, constants.CARTESIAN, fake_granule)
     assert collection_handler_mock.called
     assert collection_handler_mock.call_args.args[0] == collection_spatial
 


### PR DESCRIPTION
Apply the polygon-generation code when `.spatial` files are initially read, so that `.spo` file content is not accidentally processed.